### PR TITLE
Add support for transitional and user-assigned iso3166 country codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A country code can be retrieved for a given format with the following:
 The converter is used to convert between country code standards. Standards can be retrieved via the `StandardRegistry`.
     
 ```    
-  Converter converter = new CountryCodeConvter();
+  Converter converter = new CountryCodeConverter();
   
   StandardRegistry registry = StandardRegistryImpl.getInstance();
   StandardProvider fipsStandard = registry.lookup("FIPS", "10-4");
@@ -43,5 +43,24 @@ The converter is used to convert between country code standards. Standards can b
   
   // converting from FIPS 10-4 to ISO 3166-1 with numeric
   Set<CountryCode> convertedCountryCodes = converter.fromNumeric("004", fipsStandard.getStandard(), isoStandard.getStandard());
+
+```
+
+## Retrieve an alpha3 code from an alpha2 code
+
+```
+  StandardRegistry registry = StandardRegistryImpl.getInstance();
+  StandardProvider isoStandard = registry.lookup("ISO3166", "1");
+
+  // converting from ISO 3166-1 alpha2 to ISO 3166-1 alpha3
+  Optional<CountryCode> optionalCountryCode =
+          isoStandard
+              .getStandardEntries()
+              .stream()
+              .filter(c -> c.getAsFormat("alpha2").equals("AT"))
+              .findFirst();
+
+  if (optionalCountryCode.isPresent())
+    System.out.println(optionalCountryCode.get().getAsFormat("alpha3"));
 
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <org.slf4j.version>1.7.25</org.slf4j.version>
         <ddf.version>2.11.3</ddf.version>
         <ddf.support.version>2.3.9</ddf.support.version>
-        <guava.version>22.0</guava.version>
+        <guava.version>18.0</guava.version>
         <apache.commons.io.version>2.5</apache.commons.io.version>
         <apache.commons.collections.version>4.1</apache.commons.collections.version>
         <apache.commons.lang3.version>3.7</apache.commons.lang3.version>

--- a/standards/iso/src/main/java/org/codice/countrycode/standards/iso/Iso3166StandardProvider.java
+++ b/standards/iso/src/main/java/org/codice/countrycode/standards/iso/Iso3166StandardProvider.java
@@ -18,6 +18,8 @@ import static org.codice.countrycode.standards.iso.Iso3166Standard.ALPHA_3;
 import static org.codice.countrycode.standards.iso.Iso3166Standard.NUMERIC;
 
 import com.google.common.collect.ImmutableSet;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -35,7 +37,7 @@ public class Iso3166StandardProvider implements StandardProvider {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(Iso3166StandardProvider.class);
 
-  private static final String ISO3166_1_JSON = "iso3166-1.json";
+  private static final String[] ISO3166_1_JSON = {"iso3166-1.json", "iso3166-1-transitional.json", "iso3166-1-user-assigned.json"};
 
   private final Standard standard;
 
@@ -58,14 +60,17 @@ public class Iso3166StandardProvider implements StandardProvider {
   }
 
   private void init() {
-    List<Iso3166Code> isoCodes =
-        Boon.fromJsonArray(
-            IO.read(this.getClass().getClassLoader().getResourceAsStream(ISO3166_1_JSON), "UTF-8"),
-            Iso3166Code.class);
+    List<Iso3166Code> isoCodes = new ArrayList<>();
+
+    for (String filename : ISO3166_1_JSON) {
+      isoCodes.addAll(Boon.fromJsonArray(
+          IO.read(this.getClass().getClassLoader().getResourceAsStream(filename), "UTF-8"),
+          Iso3166Code.class));
+    }
 
     if (CollectionUtils.isEmpty(isoCodes)) {
       LOGGER.debug(
-          "ISO 3166-1 file [{}] contained no codes. Provider will be empty.", ISO3166_1_JSON);
+          "ISO 3166-1 files {} contained no codes. Provider will be empty.", Arrays.toString(ISO3166_1_JSON));
       return;
     }
 

--- a/standards/iso/src/main/resources/iso3166-1-transitional.json
+++ b/standards/iso/src/main/resources/iso3166-1-transitional.json
@@ -1,0 +1,44 @@
+[
+  {
+    "name": "Netherlands Antilles",
+    "alpha2": "AN",
+    "alpha3": "ANT",
+    "numeric": "530"
+  },
+  {
+    "name": "Burma",
+    "alpha2": "BU",
+    "alpha3": "BUR",
+    "numeric": "104"
+  },
+  {
+    "name": "Serbia and Montenegro",
+    "alpha2": "CS",
+    "alpha3": "SCG",
+    "numeric": "891"
+  },
+  {
+    "name": "Neutral Zone",
+    "alpha2": "NT",
+    "alpha3": "NTZ",
+    "numeric": "536"
+  },
+  {
+    "name": "East Timor",
+    "alpha2": "TP",
+    "alpha3": "TMP",
+    "numeric": "626"
+  },
+  {
+    "name": "Yugoslavia",
+    "alpha2": "YU",
+    "alpha3": "YUG",
+    "numeric": "891"
+  },
+  {
+    "name": "Zaire",
+    "alpha2": "ZR",
+    "alpha3": "ZAR",
+    "numeric": "180"
+  }
+]

--- a/standards/iso/src/main/resources/iso3166-1-user-assigned.json
+++ b/standards/iso/src/main/resources/iso3166-1-user-assigned.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "Kosovo",
+    "alpha2": "XK",
+    "alpha3": "XKX",
+    "numeric": "0"
+  }
+]

--- a/standards/iso/src/test/groovy/org/codice/countrycode/standards/iso/Iso3166StandardProviderSpec.groovy
+++ b/standards/iso/src/test/groovy/org/codice/countrycode/standards/iso/Iso3166StandardProviderSpec.groovy
@@ -19,6 +19,6 @@ class Iso3166StandardProviderSpec extends Specification {
 
     def 'test iso3166 provider'() {
         expect:
-        new Iso3166StandardProvider().getStandardEntries().size() == 249
+        new Iso3166StandardProvider().getStandardEntries().size() == 257
     }
 }


### PR DESCRIPTION
@jlcsmith  @bdeining 

Also changes the guava version to 18 to match DDF.