### PR TITLE
Made Converter More OSGI friendly

### DIFF
--- a/converter/pom.xml
+++ b/converter/pom.xml
@@ -136,9 +136,7 @@
                             *
                         </Import-Package>
                         <Export-Package>
-                            org.codice.countrycode.standard,
-                            org.codice.countrycode.converter,
-                            org.codice.countrycode
+                            org.codice.countrycode*
                         </Export-Package>
                     </instructions>
                 </configuration>


### PR DESCRIPTION
Export more packages such that consumers need to only list `converter` as a dependency
https://github.com/codice/countrycode/issues/2