### PR TITLE
Upgrade gson to 2.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <apache.commons.collections.version>4.1</apache.commons.collections.version>
         <apache.commons.lang3.version>3.4</apache.commons.lang3.version>
         <junit.version>4.12</junit.version>
-        <gson.version>2.8.5</gson.version>
+        <gson.version>2.9.0</gson.version>
         <jaxb.version>2.3.2</jaxb.version>
     </properties>
 


### PR DESCRIPTION
There is a CVE (https://cve.mitre.org/cgi-bin/cvename.cgi?name=2022-25647) for gson. A downstream project needs to an updated version of this project that resolves the CVE.

@jlcsmith 
@shaundmorris 
@brendan-hofmann 
