### PR TITLE
[gson-upgrade-2.13.2] upgrade gson from 2.11.0 -> 2.13.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <apache.commons.collections.version>4.4</apache.commons.collections.version>
         <apache.commons.lang3.version>3.18.0</apache.commons.lang3.version>
         <junit.version>4.13.2</junit.version>
-        <gson.version>2.11.0</gson.version>
+        <gson.version>2.13.2</gson.version>
         <jaxb.version>4.0.5</jaxb.version>
     </properties>
 


### PR DESCRIPTION
Upgrade GSon to the currently latest LTS version: 2.13.2 to resolve CVEs with 2.11.0